### PR TITLE
add older patch version to the list  (1.22.13, 1.23.10, 1.24.4, 1.25.0)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,9 +18,13 @@ jobs:
           - quay.io/kairos/core-ubuntu-22-lts:v1.1.1
         rke2-version:
           - v1.25.2+rke2r1
+          - v1.25.0+rke2r1
           - v1.24.6+rke2r1
+          - v1.24.4+rke2r1
           - v1.23.12+rke2r1
+          - v1.23.10+rke2r1
           - v1.22.15+rke2r1
+          - v1.22.13+rke2r1
         platform:
           - linux/amd64
     env:


### PR DESCRIPTION
We don’t need these  old versions (1.22.13, 1.23.10, 1.24.4, 1.25.0) for rke2/k3s, but will just build the images with new naming convention just because the pack is already out there