### PR TITLE
embed core images for status pods

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -84,6 +84,9 @@ docker:
     ENV OS_LABEL=${BASE_IMAGE_TAG}_${RKE2_VERSION_TAG}_${VERSION}
     RUN envsubst >/etc/os-release </usr/lib/os-release.tmpl
 
+    RUN mkdir -p /var/lib/rancher/rke2/agent/images
+    RUN curl -L --output /var/lib/rancher/rke2/agent/images/images.tar.zst "https://github.com/rancher/rke2/releases/download/$RKE2_VERSION/rke2-images-core.linux-amd64.tar.zst"
+
     SAVE IMAGE --push $IMAGE_REPOSITORY/${BASE_IMAGE_NAME}-rke2:${RKE2_VERSION_TAG}
     SAVE IMAGE --push $IMAGE_REPOSITORY/${BASE_IMAGE_NAME}-rke2:${RKE2_VERSION_TAG}_${VERSION}
 


### PR DESCRIPTION
embedded the core rke2 images with the image to ensure  users running with limited connectivity will be able to start a cluster.