### PR TITLE
PE-9165 chore: upgrade Go to 1.26.5 (release/v4.7.2)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -5,8 +5,8 @@ ARG BASE_IMAGE=quay.io/kairos/core-opensuse-leap:v2.4.3
 ARG IMAGE_REPOSITORY=quay.io/kairos
 
 ARG LUET_VERSION=0.35.1
-ARG GOLINT_VERSION=v2.1.6
-ARG GOLANG_VERSION=1.26.4
+ARG GOLINT_VERSION=v2.10.1
+ARG GOLANG_VERSION=1.26.5
 
 ARG RKE2_VERSION=latest
 ARG BASE_IMAGE_NAME=$(echo $BASE_IMAGE | grep -o [^/]*: | rev | cut -c2- | rev)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kairos-io/provider-rke2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/kairos-io/kairos-sdk v0.9.3


### PR DESCRIPTION
Refs PE-9165 / PEM-11529.

Cherry-picks the Go 1.26.5 bump from main (#101) onto `release/v4.7.2`
(current 4.7-line head; == `v4.7.4` tag) so the 4.7.x rke2 provider
image picks up the Go runtime CVE fixes (CVE-2026-39822,
CVE-2026-42505).

Changes:
- `go.mod`: `go 1.26.5`
- `Earthfile`: `GOLANG_VERSION=1.26.5` (+ `GOLINT_VERSION` bundled bump)

`go build`/`go test ./...` clean locally.