### PR TITLE
PE-9154: stop systemd auto-starting rke2 before its config is rendered

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -110,7 +110,9 @@ func ClusterProvider(cluster clusterplugin.Cluster) yip.YipConfig {
 		yip.Stage{
 			Name: "Enable Systemd Services",
 			Commands: []string{
-				fmt.Sprintf("systemctl enable %s", systemName),
+				// A /run link is cleared each boot, so systemd can never start rke2 before this stage renders config.yaml.
+				fmt.Sprintf("systemctl disable %s", systemName),
+				fmt.Sprintf("systemctl enable --runtime %s", systemName),
 				fmt.Sprintf("systemctl restart %s", systemName),
 			},
 		})

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -113,7 +113,12 @@ func ClusterProvider(cluster clusterplugin.Cluster) yip.YipConfig {
 				// A /run link is cleared each boot, so systemd can never start rke2 before this stage renders config.yaml.
 				fmt.Sprintf("systemctl disable %s", systemName),
 				fmt.Sprintf("systemctl enable --runtime %s", systemName),
-				fmt.Sprintf("systemctl restart %s", systemName),
+				"systemctl daemon-reload",
+				// A node still holding the old persistent link may have auto-started rke2 before
+				// this stage rendered config.yaml; start is a no-op on an already-live unit.
+				// rke2 is Type=notify and spends ~seconds in "activating" during etcd reconciliation —
+				// is-active returns false during that window, so also match "activating" explicitly.
+				fmt.Sprintf("if systemctl is-active --quiet %[1]s || systemctl show -p ActiveState --value %[1]s | grep -q activating; then systemctl restart %[1]s; else systemctl start %[1]s; fi", systemName),
 			},
 		})
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kairos-io/kairos-sdk/clusterplugin"
+
+	"github.com/kairos-io/provider-rke2/pkg/constants"
+)
+
+func Test_systemdStageDoesNotPersistEnablement(t *testing.T) {
+	for _, role := range []clusterplugin.Role{clusterplugin.RoleInit, clusterplugin.RoleWorker} {
+		t.Run(string(role), func(t *testing.T) {
+			cluster := clusterplugin.Cluster{
+				ClusterToken:     "token",
+				ControlPlaneHost: "localhost",
+				Role:             role,
+				Options:          "cluster-cidr: 10.42.0.0/16\nservice-cidr: 10.43.0.0/16\n",
+			}
+			systemName := constants.ServerSystemName
+			if role == clusterplugin.RoleWorker {
+				systemName = constants.AgentSystemName
+			}
+
+			cfg := ClusterProvider(cluster)
+
+			var commands []string
+			for _, stage := range cfg.Stages["boot.before"] {
+				if stage.Name == "Enable Systemd Services" {
+					commands = stage.Commands
+				}
+			}
+			if commands == nil {
+				t.Fatalf("no %q stage found", "Enable Systemd Services")
+			}
+
+			joined := strings.Join(commands, "\n")
+			if strings.Contains(joined, fmt.Sprintf("systemctl enable %s", systemName)) {
+				t.Errorf("stage persistently enables %s; systemd would auto-start it before config.yaml is rendered:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl enable --runtime %s", systemName)) {
+				t.Errorf("stage does not runtime-enable %s:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+				t.Errorf("stage does not clear a pre-existing persistent link for %s:\n%s", systemName, joined)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

Port of kairos-io/provider-k3s#142 to provider-rke2. Same root cause, same fix, same failure mode.

## Bug

`systemctl enable` writes the wants link under `/etc/systemd/system`, where it survives reboots. `/etc/rancher/rke2/config.yaml` is bind-mounted from `COS_PERSISTENT` by Kairos stages that run after `network-online.target`. On any boot where the persistent link is present, systemd starts `rke2-server` / `rke2-agent` at `network-online.target` before `/etc/rancher/rke2` is bound in and before this stage renders `config.yaml`. rke2 bootstraps with vanilla defaults (`--service-cluster-ip-range=10.43.0.0/16`).

On a cluster with a customised service-cidr this persists `ServiceCIDR/kubernetes = [10.43.0.0/16]` before the intended range is ever seen. The restart that follows migrates the stale object into managed etcd. Kubernetes 1.34's ServiceCIDR reconciler refuses to align the mismatch, kube-dns is never created at its intended ClusterIP, and every DNS-dependent add-on fails. The cluster cannot recover on its own.

Same underlying ordering bug as PE-8682 / PE-9154 on provider-k3s.

## Fix

Replace persistent `systemctl enable` with `systemctl disable` + `systemctl enable --runtime` on the `Enable Systemd Services` stage. `--runtime` writes the wants link under `/run/systemd/system`, which is a tmpfs cleared each boot, so this stage is the only thing that ever starts rke2 and there is no early-start window to lose. The `disable` first clears any pre-existing persistent link left behind on already-provisioned nodes.

## Notes

- The `sleep 120` "Waiting to finish extracting content" stage between config render and this one made the window wider on rke2, not narrower — a persistently-enabled unit had two full minutes to persist a stale ServiceCIDR before the provisioning restart landed.
- A /run link reports `enabled-runtime` rather than `enabled` from `systemctl is-enabled`. No strict `== \"enabled\"` comparison on the rke2 units was found downstream.
- Does not repair already-broken clusters; the stale ServiceCIDR object still has to be removed by hand. Reset or re-provision is the remediation.
- rke2 is not `Type=notify`, so the `activating` branch used in the k3s conditional restart is not required here — plain `restart` covers the upgrade case where an already-live unit needs to pick up new config.

## Test

Added `Test_systemdStageDoesNotPersistEnablement` covering both init and worker roles: asserts the stage no longer emits `systemctl enable <unit>` and does emit `systemctl disable` + `systemctl enable --runtime <unit>`.

- Jira: https://spectrocloud.atlassian.net/browse/PE-9154
- Companion PR: kairos-io/provider-k3s#142