### PR TITLE
PE-9154: stop systemd auto-starting rke2 before its config is rendered (4.9.x backport)

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -110,8 +110,15 @@ func ClusterProvider(cluster clusterplugin.Cluster) yip.YipConfig {
 		yip.Stage{
 			Name: "Enable Systemd Services",
 			Commands: []string{
-				fmt.Sprintf("systemctl enable %s", systemName),
-				fmt.Sprintf("systemctl restart %s", systemName),
+				// A /run link is cleared each boot, so systemd can never start rke2 before this stage renders config.yaml.
+				fmt.Sprintf("systemctl disable %s", systemName),
+				fmt.Sprintf("systemctl enable --runtime %s", systemName),
+				"systemctl daemon-reload",
+				// A node still holding the old persistent link may have auto-started rke2 before
+				// this stage rendered config.yaml; start is a no-op on an already-live unit.
+				// rke2 is Type=notify and spends ~seconds in "activating" during etcd reconciliation —
+				// is-active returns false during that window, so also match "activating" explicitly.
+				fmt.Sprintf("if systemctl is-active --quiet %[1]s || systemctl show -p ActiveState --value %[1]s | grep -q activating; then systemctl restart %[1]s; else systemctl start %[1]s; fi", systemName),
 			},
 		})
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kairos-io/kairos-sdk/clusterplugin"
+
+	"github.com/kairos-io/provider-rke2/pkg/constants"
+)
+
+func Test_systemdStageDoesNotPersistEnablement(t *testing.T) {
+	for _, role := range []clusterplugin.Role{clusterplugin.RoleInit, clusterplugin.RoleWorker} {
+		t.Run(string(role), func(t *testing.T) {
+			cluster := clusterplugin.Cluster{
+				ClusterToken:     "token",
+				ControlPlaneHost: "localhost",
+				Role:             role,
+				Options:          "cluster-cidr: 10.42.0.0/16\nservice-cidr: 10.43.0.0/16\n",
+			}
+			systemName := constants.ServerSystemName
+			if role == clusterplugin.RoleWorker {
+				systemName = constants.AgentSystemName
+			}
+
+			cfg := ClusterProvider(cluster)
+
+			var commands []string
+			for _, stage := range cfg.Stages["boot.before"] {
+				if stage.Name == "Enable Systemd Services" {
+					commands = stage.Commands
+				}
+			}
+			if commands == nil {
+				t.Fatalf("no %q stage found", "Enable Systemd Services")
+			}
+
+			joined := strings.Join(commands, "\n")
+			if strings.Contains(joined, fmt.Sprintf("systemctl enable %s", systemName)) {
+				t.Errorf("stage persistently enables %s; systemd would auto-start it before config.yaml is rendered:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl enable --runtime %s", systemName)) {
+				t.Errorf("stage does not runtime-enable %s:\n%s", systemName, joined)
+			}
+			if !strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+				t.Errorf("stage does not clear a pre-existing persistent link for %s:\n%s", systemName, joined)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Backport of #105 onto `spectro-release-4.9`.
- Replaces persistent `systemctl enable` with `systemctl disable` + `systemctl enable --runtime`, and guards restart so rke2 cannot bootstrap from vanilla defaults before `config.yaml` is rendered.
- Same root cause / fix as PE-8682 / PE-9154 on provider-k3s.

## Test plan
- [x] `go test ./pkg/provider/...` on the backport branch
- [ ] Verify Edge 4.9 image with custom service-cidr does not persist `ServiceCIDR/kubernetes = [10.43.0.0/16]` across reboot
- [ ] Confirm `systemctl is-enabled rke2-server|rke2-agent` reports `enabled-runtime` after the stage runs

Cherry-picked from: 7e8d098 (`#105`)
Jira: https://spectrocloud.atlassian.net/browse/PE-9154


Made with [Cursor](https://cursor.com)