### PR TITLE
PE-9154: keep the rke2 unit intact on UKI images

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -111,7 +111,8 @@ func ClusterProvider(cluster clusterplugin.Cluster) yip.YipConfig {
 			Name: "Enable Systemd Services",
 			Commands: []string{
 				// A /run link is cleared each boot, so systemd can never start rke2 before this stage renders config.yaml.
-				fmt.Sprintf("systemctl disable %s", systemName),
+				// Not `systemctl disable`: on UKI the unit is a symlink into /opt/k8s, which disable deletes.
+				fmt.Sprintf("rm -f /etc/systemd/system/*.wants/%[1]s.service /etc/systemd/system/*.requires/%[1]s.service", systemName),
 				fmt.Sprintf("systemctl enable --runtime %s", systemName),
 				"systemctl daemon-reload",
 				// A node still holding the old persistent link may have auto-started rke2 before

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -43,8 +43,11 @@ func Test_systemdStageDoesNotPersistEnablement(t *testing.T) {
 			if !strings.Contains(joined, fmt.Sprintf("systemctl enable --runtime %s", systemName)) {
 				t.Errorf("stage does not runtime-enable %s:\n%s", systemName, joined)
 			}
-			if !strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+			if !strings.Contains(joined, fmt.Sprintf("/etc/systemd/system/*.wants/%s.service", systemName)) {
 				t.Errorf("stage does not clear a pre-existing persistent link for %s:\n%s", systemName, joined)
+			}
+			if strings.Contains(joined, fmt.Sprintf("systemctl disable %s", systemName)) {
+				t.Errorf("stage disables %s; on UKI that deletes the unit symlink:\n%s", systemName, joined)
 			}
 		})
 	}


### PR DESCRIPTION
The systemctl disable added by #105 does more than clear the enable state: on UKI images etc/systemd/system/rke2-server.service is a symlink into /opt/k8s (laid down by  CanvOS slink), and systemd treats a unit symlink pointing outside its search paths as an alias to dismantle — so disable deletes the unit itself. The following enable  --runtime and start then fail, kairos-agent swallows both, and the node boots with no rke2 and no cluster; nothing recreates the symlink, so it stays broken. This removes the install links by path instead, which clears the persistent wants link exactly as disable did but cannot touch the unit file. Same fix as  kairos-io/provider-k3s#146, which was validated on a real UKI node; the existing test assertion that required disable is inverted accordingly.